### PR TITLE
GitHub Actions CI/CD 2차 테스트

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -47,4 +47,4 @@ jobs:
           version_label: github-action-${{ github.sha }}
           region: ap-northeast-2
           deployment_package: deploy/deploy.zip
-          wait_for_deployment: true
+          wait_for_deployment: false


### PR DESCRIPTION
GitHub Actions CI/CD 2차 테스트입니다. 
기존에 1차 테스트가 실패로 끝났던 이유가 Elastic Beanstalk 환경변수에서 PORT가 5000번대로 설정되어 있어서 그런것 같습니다. 그래서 PORT를 다시 8080번대(Spring Boot)로 수정하고 Valkey, RDS 설정도 해줬습니다.

이번 테스트가 마지막이길 기도합니다.. 🙏