### PR TITLE
결제 히스토리 관련 API 구현

### DIFF
--- a/src/main/java/com/subnity/domain/payment_history/PaymentHistory.java
+++ b/src/main/java/com/subnity/domain/payment_history/PaymentHistory.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 public class PaymentHistory extends BaseTimeEntity {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "payment_history_id", nullable = false)
   private Long paymentHistoryId;
 

--- a/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
+++ b/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
@@ -1,0 +1,15 @@
+package com.subnity.domain.payment_history.controller;
+
+import com.subnity.domain.payment_history.service.PaymentHistoryService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/payment")
+@RequiredArgsConstructor
+@Tag(name = "Payment History", description = "결제 히스토리 관련 API")
+public class PaymentHistoryController {
+  private final PaymentHistoryService paymentHistoryService;
+}

--- a/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
+++ b/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
@@ -10,6 +10,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping(value = "/payment")
 @RequiredArgsConstructor
@@ -28,5 +30,11 @@ public class PaymentHistoryController {
   @Operation(summary = "특정 결제 히스토리 조회", description = "특정 결제 히스토리 조회 엔드포인트")
   public ApiResponse<DetailPaymentHistoryResponse> getPaymentHistory(@PathVariable("id") String paymentHistoryId) {
     return ApiResponse.onSuccess(paymentHistoryService.getPaymentHistory(paymentHistoryId));
+  }
+
+  @GetMapping(value = "/list")
+  @Operation(summary = "결제 히스토리 목록 조회", description = "결제 히스토리 목록 조회 엔드포인트")
+  public ApiResponse<List<DetailPaymentHistoryResponse>> getPaymentHistoryList() {
+    return ApiResponse.onSuccess(paymentHistoryService.getPaymentHistoryList());
   }
 }

--- a/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
+++ b/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
@@ -2,15 +2,13 @@ package com.subnity.domain.payment_history.controller;
 
 import com.subnity.common.api_response.ApiResponse;
 import com.subnity.domain.payment_history.controller.request.CreatePaymentHistoryRequest;
+import com.subnity.domain.payment_history.controller.response.DetailPaymentHistoryResponse;
 import com.subnity.domain.payment_history.service.PaymentHistoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(value = "/payment")
@@ -24,5 +22,11 @@ public class PaymentHistoryController {
   public ApiResponse<Void> createPaymentHistory(@RequestBody @Valid CreatePaymentHistoryRequest request) {
     paymentHistoryService.createPaymentHistory(request);
     return ApiResponse.onSuccess();
+  }
+
+  @GetMapping(value = "/{id}")
+  @Operation(summary = "특정 결제 히스토리 조회", description = "특정 결제 히스토리 조회 엔드포인트")
+  public ApiResponse<DetailPaymentHistoryResponse> getPaymentHistory(@PathVariable("id") String paymentHistoryId) {
+    return ApiResponse.onSuccess(paymentHistoryService.getPaymentHistory(paymentHistoryId));
   }
 }

--- a/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
+++ b/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
@@ -37,4 +37,10 @@ public class PaymentHistoryController {
   public ApiResponse<List<DetailPaymentHistoryResponse>> getPaymentHistoryList() {
     return ApiResponse.onSuccess(paymentHistoryService.getPaymentHistoryList());
   }
+
+  @GetMapping(value = "/list/{subscrId}")
+  @Operation(summary = "특정 구독 결제 히스토리 목록 조회", description = "특정 구독 결제 히스토리 목록 조회 엔드포인트")
+  public ApiResponse<List<DetailPaymentHistoryResponse>> getPaymentHistoryListBySubscrId(@PathVariable("subscrId") String subscrId) {
+    return ApiResponse.onSuccess(paymentHistoryService.getPaymentHistoryListBySubscrId(subscrId));
+  }
 }

--- a/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
+++ b/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
@@ -1,8 +1,14 @@
 package com.subnity.domain.payment_history.controller;
 
+import com.subnity.common.api_response.ApiResponse;
+import com.subnity.domain.payment_history.controller.request.CreatePaymentHistoryRequest;
 import com.subnity.domain.payment_history.service.PaymentHistoryService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,4 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Payment History", description = "결제 히스토리 관련 API")
 public class PaymentHistoryController {
   private final PaymentHistoryService paymentHistoryService;
+
+  @PostMapping(value = "/create")
+  @Operation(summary = "결제 히스토리 등록", description = "결제 히스토리 등록 엔드포인트")
+  public ApiResponse<Void> createPaymentHistory(@RequestBody @Valid CreatePaymentHistoryRequest request) {
+    paymentHistoryService.createPaymentHistory(request);
+    return ApiResponse.onSuccess();
+  }
 }

--- a/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
+++ b/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
@@ -2,7 +2,7 @@ package com.subnity.domain.payment_history.controller;
 
 import com.subnity.common.api_response.ApiResponse;
 import com.subnity.domain.payment_history.controller.request.CreatePaymentHistoryRequest;
-import com.subnity.domain.payment_history.controller.response.DetailPaymentHistoryResponse;
+import com.subnity.domain.payment_history.controller.response.GetPaymentHistoryResponse;
 import com.subnity.domain.payment_history.service.PaymentHistoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +12,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * PaymentHistoryController : 결제 히스토리 Controller
+ */
 @RestController
 @RequestMapping(value = "/payment")
 @RequiredArgsConstructor
@@ -19,6 +22,11 @@ import java.util.List;
 public class PaymentHistoryController {
   private final PaymentHistoryService paymentHistoryService;
 
+  /**
+   * 결제 히스토리 등록 엔드포인트
+   * @param request : 결제 히스토리 생성 요청 객체
+   * @return : 공통 응답 객체 반환
+   */
   @PostMapping(value = "/create")
   @Operation(summary = "결제 히스토리 등록", description = "결제 히스토리 등록 엔드포인트")
   public ApiResponse<Void> createPaymentHistory(@RequestBody @Valid CreatePaymentHistoryRequest request) {
@@ -26,24 +34,43 @@ public class PaymentHistoryController {
     return ApiResponse.onSuccess();
   }
 
+  /**
+   * 특정 결제 히스토리 조회 엔드포인트
+   * @param paymentHistoryId : 결제 히스토리 ID
+   * @return : 결제 히스토리 조회 응답 객체 반환
+   */
   @GetMapping(value = "/{id}")
   @Operation(summary = "특정 결제 히스토리 조회", description = "특정 결제 히스토리 조회 엔드포인트")
-  public ApiResponse<DetailPaymentHistoryResponse> getPaymentHistory(@PathVariable("id") String paymentHistoryId) {
+  public ApiResponse<GetPaymentHistoryResponse> getPaymentHistory(@PathVariable("id") String paymentHistoryId) {
     return ApiResponse.onSuccess(paymentHistoryService.getPaymentHistory(paymentHistoryId));
   }
 
+  /**
+   * 회원 결제 히스토리 목록 조회 엔드포인트
+   * @return : 결제 히스토리 목록 조회 응답 객체 반환
+   */
   @GetMapping(value = "/list")
   @Operation(summary = "결제 히스토리 목록 조회", description = "결제 히스토리 목록 조회 엔드포인트")
-  public ApiResponse<List<DetailPaymentHistoryResponse>> getPaymentHistoryList() {
+  public ApiResponse<List<GetPaymentHistoryResponse>> getPaymentHistoryList() {
     return ApiResponse.onSuccess(paymentHistoryService.getPaymentHistoryList());
   }
 
+  /**
+   * 특정 구독 결제 히스토리 목록 조회 엔드포인트
+   * @param subscrId : 구독 ID
+   * @return : 결제 히스토리 목록 조회 응답 객체 반환
+   */
   @GetMapping(value = "/list/{subscrId}")
   @Operation(summary = "특정 구독 결제 히스토리 목록 조회", description = "특정 구독 결제 히스토리 목록 조회 엔드포인트")
-  public ApiResponse<List<DetailPaymentHistoryResponse>> getPaymentHistoryListBySubscrId(@PathVariable("subscrId") String subscrId) {
+  public ApiResponse<List<GetPaymentHistoryResponse>> getPaymentHistoryListBySubscrId(@PathVariable("subscrId") String subscrId) {
     return ApiResponse.onSuccess(paymentHistoryService.getPaymentHistoryListBySubscrId(subscrId));
   }
 
+  /**
+   * 특정 결제 히스토리 삭제 엔드포인트
+   * @param paymentHistoryId : 결제 히스토리 ID
+   * @return : 공통 응답 객체 반환
+   */
   @DeleteMapping(value = "/delete/{id}")
   @Operation(summary = "특정 결제 히스토리 삭제", description = "특정 결제 히스토리 삭제 엔드포인트")
   public ApiResponse<Void> deletePaymentHistory(@PathVariable("id") String paymentHistoryId) {

--- a/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
+++ b/src/main/java/com/subnity/domain/payment_history/controller/PaymentHistoryController.java
@@ -43,4 +43,11 @@ public class PaymentHistoryController {
   public ApiResponse<List<DetailPaymentHistoryResponse>> getPaymentHistoryListBySubscrId(@PathVariable("subscrId") String subscrId) {
     return ApiResponse.onSuccess(paymentHistoryService.getPaymentHistoryListBySubscrId(subscrId));
   }
+
+  @DeleteMapping(value = "/delete/{id}")
+  @Operation(summary = "특정 결제 히스토리 삭제", description = "특정 결제 히스토리 삭제 엔드포인트")
+  public ApiResponse<Void> deletePaymentHistory(@PathVariable("id") String paymentHistoryId) {
+    paymentHistoryService.deletePaymentHistory(paymentHistoryId);
+    return ApiResponse.onSuccess();
+  }
 }

--- a/src/main/java/com/subnity/domain/payment_history/controller/request/CreatePaymentHistoryRequest.java
+++ b/src/main/java/com/subnity/domain/payment_history/controller/request/CreatePaymentHistoryRequest.java
@@ -1,0 +1,30 @@
+package com.subnity.domain.payment_history.controller.request;
+
+import com.subnity.domain.payment_history.enums.PaymentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "결제 히스토리 생성 요청 객체")
+public class CreatePaymentHistoryRequest {
+
+  @Schema(description = "결제 금액")
+  private String cost;
+
+  @Schema(description = "결제일")
+  private LocalDate paymentDate;
+
+  @Schema(description = "결제 상태")
+  private PaymentStatus status;
+
+  @Schema(description = "구독 ID")
+  private long subscrId;
+}

--- a/src/main/java/com/subnity/domain/payment_history/controller/response/DetailPaymentHistoryResponse.java
+++ b/src/main/java/com/subnity/domain/payment_history/controller/response/DetailPaymentHistoryResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -17,13 +18,16 @@ import java.time.LocalDate;
 public class DetailPaymentHistoryResponse {
 
   @Schema(description = "결제 히스토리 ID")
-  private Long paymentHistoryId;
+  private long paymentHistoryId;
+
+  @Schema(description = "구독 ID")
+  private long subscrId;
 
   @Schema(description = "요금")
   private String cost;
 
   @Schema(description = "결제일")
-  private LocalDate paymentDate;
+  private LocalDateTime paymentDate;
 
   @Schema(description = "결제 상태")
   private PaymentStatus paymentStatus;

--- a/src/main/java/com/subnity/domain/payment_history/controller/response/GetPaymentHistoryResponse.java
+++ b/src/main/java/com/subnity/domain/payment_history/controller/response/GetPaymentHistoryResponse.java
@@ -7,15 +7,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Schema(description = "결제 히스토리 정보 상세 조회 응답 객체")
-public class DetailPaymentHistoryResponse {
+@Schema(description = "결제 히스토리 정보 조회 응답 객체")
+public class GetPaymentHistoryResponse {
 
   @Schema(description = "결제 히스토리 ID")
   private long paymentHistoryId;
@@ -23,7 +22,7 @@ public class DetailPaymentHistoryResponse {
   @Schema(description = "구독 ID")
   private long subscrId;
 
-  @Schema(description = "요금")
+  @Schema(description = "결제 금액")
   private String cost;
 
   @Schema(description = "결제일")

--- a/src/main/java/com/subnity/domain/payment_history/enums/PaymentStatus.java
+++ b/src/main/java/com/subnity/domain/payment_history/enums/PaymentStatus.java
@@ -1,8 +1,14 @@
 package com.subnity.domain.payment_history.enums;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public enum PaymentStatus {
-  SUCCESS, FAILURE
+
+  SUCCESS("성공"),
+  FAILURE("실패");
+
+  private final String value;
 }

--- a/src/main/java/com/subnity/domain/payment_history/repository/JpaPaymentHistoryRepository.java
+++ b/src/main/java/com/subnity/domain/payment_history/repository/JpaPaymentHistoryRepository.java
@@ -1,0 +1,9 @@
+package com.subnity.domain.payment_history.repository;
+
+import com.subnity.domain.payment_history.PaymentHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaPaymentHistoryRepository extends JpaRepository<PaymentHistory, Long> {
+}

--- a/src/main/java/com/subnity/domain/payment_history/repository/PaymentHistoryRepository.java
+++ b/src/main/java/com/subnity/domain/payment_history/repository/PaymentHistoryRepository.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static com.subnity.domain.payment_history.QPaymentHistory.paymentHistory;
 
@@ -39,5 +40,21 @@ public class PaymentHistoryRepository {
     .from(paymentHistory)
     .where(paymentHistory.paymentHistoryId.eq(paymentHistoryId))
     .fetchOne();
+  }
+
+  public List<DetailPaymentHistoryResponse> paymentHistoryList(String memberId) {
+    return queryFactory.select(
+      Projections.fields(
+        DetailPaymentHistoryResponse.class,
+        paymentHistory.paymentHistoryId,
+        paymentHistory.subscription.subscriptionId.as("subscrId"),
+        paymentHistory.cost,
+        paymentHistory.paymentDate,
+        paymentHistory.paymentStatus
+      )
+    )
+    .from(paymentHistory)
+    .where(paymentHistory.subscription.member.memberId.eq(memberId))
+    .fetch();
   }
 }

--- a/src/main/java/com/subnity/domain/payment_history/repository/PaymentHistoryRepository.java
+++ b/src/main/java/com/subnity/domain/payment_history/repository/PaymentHistoryRepository.java
@@ -3,7 +3,7 @@ package com.subnity.domain.payment_history.repository;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.subnity.domain.payment_history.controller.request.CreatePaymentHistoryRequest;
-import com.subnity.domain.payment_history.controller.response.DetailPaymentHistoryResponse;
+import com.subnity.domain.payment_history.controller.response.GetPaymentHistoryResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -13,23 +13,49 @@ import java.util.List;
 
 import static com.subnity.domain.payment_history.QPaymentHistory.paymentHistory;
 
+/**
+ * PaymentHistoryRepository : 결제 히스토리 관련 QueryDsl Repository
+ */
 @Repository
 @RequiredArgsConstructor
 public class PaymentHistoryRepository {
   private final JPAQueryFactory queryFactory;
 
+  /**
+   * 결제 히스토리 등록
+   * @param request : 결제 히스토리 생성 요청 객체
+   * @param now : 요청 시간
+   */
   @Transactional
   public void save(CreatePaymentHistoryRequest request, LocalDateTime now) {
     queryFactory.insert(paymentHistory)
-      .columns(paymentHistory.cost, paymentHistory.paymentDate, paymentHistory.paymentStatus, paymentHistory.subscription.subscriptionId, paymentHistory._super.createdAt, paymentHistory._super.updatedAt)
-      .values(request.getCost(), request.getPaymentDate(), request.getStatus(), request.getSubscrId(), now, now)
+      .columns(
+        paymentHistory.cost,
+        paymentHistory.paymentDate,
+        paymentHistory.paymentStatus,
+        paymentHistory.subscription.subscriptionId,
+        paymentHistory._super.createdAt,
+        paymentHistory._super.updatedAt
+      )
+      .values(
+        request.getCost(),
+        request.getPaymentDate(),
+        request.getStatus(),
+        request.getSubscrId(),
+        now, now
+      )
       .execute();
   }
 
-  public DetailPaymentHistoryResponse paymentHistoryById(long paymentHistoryId) {
+  /**
+   * 결제 히스토리 조회
+   * @param paymentHistoryId : 결제 히스토리 ID
+   * @return : 특정 결제 히스토리 반환
+   */
+  public GetPaymentHistoryResponse paymentHistoryById(long paymentHistoryId) {
     return queryFactory.select(
       Projections.fields(
-        DetailPaymentHistoryResponse.class,
+        GetPaymentHistoryResponse.class,
         paymentHistory.paymentHistoryId,
         paymentHistory.subscription.subscriptionId.as("subscrId"),
         paymentHistory.cost,
@@ -42,10 +68,15 @@ public class PaymentHistoryRepository {
     .fetchOne();
   }
 
-  public List<DetailPaymentHistoryResponse> paymentHistoryList(String memberId) {
+  /**
+   * 결제 히스토리 목록 조회
+   * @param memberId : 회원 ID
+   * @return : 결제 히스토리 목록 반환
+   */
+  public List<GetPaymentHistoryResponse> paymentHistoryList(String memberId) {
     return queryFactory.select(
       Projections.fields(
-        DetailPaymentHistoryResponse.class,
+        GetPaymentHistoryResponse.class,
         paymentHistory.paymentHistoryId,
         paymentHistory.subscription.subscriptionId.as("subscrId"),
         paymentHistory.cost,
@@ -58,10 +89,16 @@ public class PaymentHistoryRepository {
     .fetch();
   }
 
-  public List<DetailPaymentHistoryResponse> paymentHistoryListBySubscrId(long subscrId, String memberId) {
+  /**
+   * 특정 구독 결제 히스토리 목록 조회
+   * @param subscrId : 구독 ID
+   * @param memberId : 회원 ID
+   * @return : 결제 히스토리 목록 반환
+   */
+  public List<GetPaymentHistoryResponse> paymentHistoryListBySubscrId(long subscrId, String memberId) {
     return queryFactory.select(
         Projections.fields(
-          DetailPaymentHistoryResponse.class,
+          GetPaymentHistoryResponse.class,
           paymentHistory.paymentHistoryId,
           paymentHistory.subscription.subscriptionId.as("subscrId"),
           paymentHistory.cost,

--- a/src/main/java/com/subnity/domain/payment_history/repository/PaymentHistoryRepository.java
+++ b/src/main/java/com/subnity/domain/payment_history/repository/PaymentHistoryRepository.java
@@ -1,9 +1,25 @@
 package com.subnity.domain.payment_history.repository;
 
-import com.subnity.domain.payment_history.PaymentHistory;
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.subnity.domain.payment_history.controller.request.CreatePaymentHistoryRequest;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+
+import static com.subnity.domain.payment_history.QPaymentHistory.paymentHistory;
+
 @Repository
-public interface PaymentHistoryRepository extends JpaRepository<PaymentHistory, Long> {
+@RequiredArgsConstructor
+public class PaymentHistoryRepository {
+  private final JPAQueryFactory queryFactory;
+
+  @Transactional
+  public void save(CreatePaymentHistoryRequest request, LocalDateTime now) {
+    queryFactory.insert(paymentHistory)
+      .columns(paymentHistory.cost, paymentHistory.paymentDate, paymentHistory.paymentStatus, paymentHistory.subscription.subscriptionId, paymentHistory._super.createdAt, paymentHistory._super.updatedAt)
+      .values(request.getCost(), request.getPaymentDate(), request.getStatus(), request.getSubscrId(), now, now)
+      .execute();
+  }
 }

--- a/src/main/java/com/subnity/domain/payment_history/repository/PaymentHistoryRepository.java
+++ b/src/main/java/com/subnity/domain/payment_history/repository/PaymentHistoryRepository.java
@@ -57,4 +57,23 @@ public class PaymentHistoryRepository {
     .where(paymentHistory.subscription.member.memberId.eq(memberId))
     .fetch();
   }
+
+  public List<DetailPaymentHistoryResponse> paymentHistoryListBySubscrId(long subscrId, String memberId) {
+    return queryFactory.select(
+        Projections.fields(
+          DetailPaymentHistoryResponse.class,
+          paymentHistory.paymentHistoryId,
+          paymentHistory.subscription.subscriptionId.as("subscrId"),
+          paymentHistory.cost,
+          paymentHistory.paymentDate,
+          paymentHistory.paymentStatus
+        )
+      )
+      .from(paymentHistory)
+      .where(
+        paymentHistory.subscription.subscriptionId.eq(subscrId),
+        paymentHistory.subscription.member.memberId.eq(memberId)
+      )
+      .fetch();
+  }
 }

--- a/src/main/java/com/subnity/domain/payment_history/repository/PaymentHistoryRepository.java
+++ b/src/main/java/com/subnity/domain/payment_history/repository/PaymentHistoryRepository.java
@@ -1,7 +1,9 @@
 package com.subnity.domain.payment_history.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.subnity.domain.payment_history.controller.request.CreatePaymentHistoryRequest;
+import com.subnity.domain.payment_history.controller.response.DetailPaymentHistoryResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -21,5 +23,21 @@ public class PaymentHistoryRepository {
       .columns(paymentHistory.cost, paymentHistory.paymentDate, paymentHistory.paymentStatus, paymentHistory.subscription.subscriptionId, paymentHistory._super.createdAt, paymentHistory._super.updatedAt)
       .values(request.getCost(), request.getPaymentDate(), request.getStatus(), request.getSubscrId(), now, now)
       .execute();
+  }
+
+  public DetailPaymentHistoryResponse paymentHistoryById(long paymentHistoryId) {
+    return queryFactory.select(
+      Projections.fields(
+        DetailPaymentHistoryResponse.class,
+        paymentHistory.paymentHistoryId,
+        paymentHistory.subscription.subscriptionId.as("subscrId"),
+        paymentHistory.cost,
+        paymentHistory.paymentDate,
+        paymentHistory.paymentStatus
+      )
+    )
+    .from(paymentHistory)
+    .where(paymentHistory.paymentHistoryId.eq(paymentHistoryId))
+    .fetchOne();
   }
 }

--- a/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
+++ b/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
@@ -1,5 +1,6 @@
 package com.subnity.domain.payment_history.service;
 
+import com.subnity.auth.utils.SecurityUtils;
 import com.subnity.domain.payment_history.controller.request.CreatePaymentHistoryRequest;
 import com.subnity.domain.payment_history.controller.response.DetailPaymentHistoryResponse;
 import com.subnity.domain.payment_history.repository.PaymentHistoryRepository;
@@ -7,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -19,5 +21,10 @@ public class PaymentHistoryService {
 
   public DetailPaymentHistoryResponse getPaymentHistory(String paymentHistoryId) {
     return paymentHistoryRepository.paymentHistoryById(Long.parseLong(paymentHistoryId));
+  }
+
+  public List<DetailPaymentHistoryResponse> getPaymentHistoryList() {
+    String memberId = SecurityUtils.getAuthMemberId();
+    return paymentHistoryRepository.paymentHistoryList(memberId);
   }
 }

--- a/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
+++ b/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
@@ -2,7 +2,7 @@ package com.subnity.domain.payment_history.service;
 
 import com.subnity.auth.utils.SecurityUtils;
 import com.subnity.domain.payment_history.controller.request.CreatePaymentHistoryRequest;
-import com.subnity.domain.payment_history.controller.response.DetailPaymentHistoryResponse;
+import com.subnity.domain.payment_history.controller.response.GetPaymentHistoryResponse;
 import com.subnity.domain.payment_history.repository.JpaPaymentHistoryRepository;
 import com.subnity.domain.payment_history.repository.PaymentHistoryRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,30 +11,56 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * PaymentHistoryService : 결제 히스토리 관련 Service
+ */
 @Service
 @RequiredArgsConstructor
 public class PaymentHistoryService {
+
   private final PaymentHistoryRepository paymentHistoryRepository;
   private final JpaPaymentHistoryRepository jpaPaymentHistoryRepository;
 
+  /**
+   * 결제 히스토리 등록 메서드
+   * @param request : 결제 히스토리 생성 요청 객체
+   */
   public void createPaymentHistory(CreatePaymentHistoryRequest request) {
     paymentHistoryRepository.save(request, LocalDateTime.now());
   }
 
-  public DetailPaymentHistoryResponse getPaymentHistory(String paymentHistoryId) {
+  /**
+   * 특정 결제 히스토리 조회 메서드
+   * @param paymentHistoryId : 결제 히스토리 ID
+   * @return : 결제 히스토리 조회 응답 객체 반환
+   */
+  public GetPaymentHistoryResponse getPaymentHistory(String paymentHistoryId) {
     return paymentHistoryRepository.paymentHistoryById(Long.parseLong(paymentHistoryId));
   }
 
-  public List<DetailPaymentHistoryResponse> getPaymentHistoryList() {
+  /**
+   * 결제 히스토리 목록 조회 메서드
+   * @return : 결제 히스토리 목록 조회 응답 객체 반환
+   */
+  public List<GetPaymentHistoryResponse> getPaymentHistoryList() {
     String memberId = SecurityUtils.getAuthMemberId();
     return paymentHistoryRepository.paymentHistoryList(memberId);
   }
 
-  public List<DetailPaymentHistoryResponse> getPaymentHistoryListBySubscrId(String subscrId) {
+  /**
+   * 특정 구독 결제 히스토리 목록 조회 메서드
+   * @param subscrId : 구독 ID
+   * @return : 결제 히스토리 목록 조회 응답 객체 반환
+   */
+  public List<GetPaymentHistoryResponse> getPaymentHistoryListBySubscrId(String subscrId) {
     String memberId = SecurityUtils.getAuthMemberId();
     return paymentHistoryRepository.paymentHistoryListBySubscrId(Long.parseLong(subscrId), memberId);
   }
 
+  /**
+   * 특정 결제 히스토리 삭제 메서드
+   * @param paymentHistoryId : 결제 히스토리 ID
+   */
   public void deletePaymentHistory(String paymentHistoryId) {
     jpaPaymentHistoryRepository.deleteById(Long.parseLong(paymentHistoryId));
   }

--- a/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
+++ b/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
@@ -3,6 +3,7 @@ package com.subnity.domain.payment_history.service;
 import com.subnity.auth.utils.SecurityUtils;
 import com.subnity.domain.payment_history.controller.request.CreatePaymentHistoryRequest;
 import com.subnity.domain.payment_history.controller.response.DetailPaymentHistoryResponse;
+import com.subnity.domain.payment_history.repository.JpaPaymentHistoryRepository;
 import com.subnity.domain.payment_history.repository.PaymentHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PaymentHistoryService {
   private final PaymentHistoryRepository paymentHistoryRepository;
+  private final JpaPaymentHistoryRepository jpaPaymentHistoryRepository;
 
   public void createPaymentHistory(CreatePaymentHistoryRequest request) {
     paymentHistoryRepository.save(request, LocalDateTime.now());
@@ -31,5 +33,9 @@ public class PaymentHistoryService {
   public List<DetailPaymentHistoryResponse> getPaymentHistoryListBySubscrId(String subscrId) {
     String memberId = SecurityUtils.getAuthMemberId();
     return paymentHistoryRepository.paymentHistoryListBySubscrId(Long.parseLong(subscrId), memberId);
+  }
+
+  public void deletePaymentHistory(String paymentHistoryId) {
+    jpaPaymentHistoryRepository.deleteById(Long.parseLong(paymentHistoryId));
   }
 }

--- a/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
+++ b/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
@@ -1,6 +1,7 @@
 package com.subnity.domain.payment_history.service;
 
 import com.subnity.domain.payment_history.controller.request.CreatePaymentHistoryRequest;
+import com.subnity.domain.payment_history.controller.response.DetailPaymentHistoryResponse;
 import com.subnity.domain.payment_history.repository.PaymentHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,5 +15,9 @@ public class PaymentHistoryService {
 
   public void createPaymentHistory(CreatePaymentHistoryRequest request) {
     paymentHistoryRepository.save(request, LocalDateTime.now());
+  }
+
+  public DetailPaymentHistoryResponse getPaymentHistory(String paymentHistoryId) {
+    return paymentHistoryRepository.paymentHistoryById(Long.parseLong(paymentHistoryId));
   }
 }

--- a/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
+++ b/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
@@ -1,0 +1,10 @@
+package com.subnity.domain.payment_history.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentHistoryService {
+
+}

--- a/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
+++ b/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
@@ -1,10 +1,18 @@
 package com.subnity.domain.payment_history.service;
 
+import com.subnity.domain.payment_history.controller.request.CreatePaymentHistoryRequest;
+import com.subnity.domain.payment_history.repository.PaymentHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class PaymentHistoryService {
+  private final PaymentHistoryRepository paymentHistoryRepository;
 
+  public void createPaymentHistory(CreatePaymentHistoryRequest request) {
+    paymentHistoryRepository.save(request, LocalDateTime.now());
+  }
 }

--- a/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
+++ b/src/main/java/com/subnity/domain/payment_history/service/PaymentHistoryService.java
@@ -27,4 +27,9 @@ public class PaymentHistoryService {
     String memberId = SecurityUtils.getAuthMemberId();
     return paymentHistoryRepository.paymentHistoryList(memberId);
   }
+
+  public List<DetailPaymentHistoryResponse> getPaymentHistoryListBySubscrId(String subscrId) {
+    String memberId = SecurityUtils.getAuthMemberId();
+    return paymentHistoryRepository.paymentHistoryListBySubscrId(Long.parseLong(subscrId), memberId);
+  }
 }

--- a/src/main/java/com/subnity/enum_api/controller/EnumController.java
+++ b/src/main/java/com/subnity/enum_api/controller/EnumController.java
@@ -34,4 +34,10 @@ public class EnumController {
   public ApiResponse<ListEnumResponse> getPaymentCycleEnumList() {
     return ApiResponse.onSuccess(enumService.getPaymentCycleEnumList());
   }
+
+  @GetMapping(value = "/payment-status")
+  @Operation(summary = "결제 상태", description = "결제 상태 Enum 목록 조회")
+  public ApiResponse<ListEnumResponse> getPaymentStatusEnumList() {
+    return ApiResponse.onSuccess(enumService.getPaymentStatusEnumList());
+  }
 }

--- a/src/main/java/com/subnity/enum_api/service/EnumService.java
+++ b/src/main/java/com/subnity/enum_api/service/EnumService.java
@@ -2,6 +2,7 @@ package com.subnity.enum_api.service;
 
 import com.subnity.common.utils.enums.SubscrCategory;
 import com.subnity.common.utils.enums.SubscrStatus;
+import com.subnity.domain.payment_history.enums.PaymentStatus;
 import com.subnity.domain.subscription.enums.PaymentCycle;
 import com.subnity.enum_api.controller.response.ListEnumDto;
 import com.subnity.enum_api.controller.response.ListEnumResponse;
@@ -55,6 +56,24 @@ public class EnumService {
    */
   public ListEnumResponse getSubscrStatusEnumList() {
     List<ListEnumDto> enumList = Stream.of(SubscrStatus.values())
+      .map(e ->
+        ListEnumDto.builder()
+          .code(e.name())
+          .value(e.getValue())
+          .build()
+      ).toList();
+
+    return ListEnumResponse.builder()
+      .enumList(enumList)
+      .build();
+  }
+
+  /**
+   * PaymentStatus Enum 목록 조회
+   * @return : PaymentStatus Enum 응답 객체 반환
+   */
+  public ListEnumResponse getPaymentStatusEnumList() {
+    List<ListEnumDto> enumList = Stream.of(PaymentStatus.values())
       .map(e ->
         ListEnumDto.builder()
           .code(e.name())


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #38

## 📝 작업 내용
해당 브랜치에서는 결제 히스토리 관련 API를 구현했습니다. 기본적인 CRUD라 구현하는데 어렵지는 않았습니다. 🤣
구현한 기능은 아래와 같습니다.
* 결제 히스토리 CRUD
* 특정 구독 결제 히스토리 목록 조회 기능

### 스크린샷 (선택)
<img width="1723" height="691" alt="Screenshot 2025-07-21 at 4 28 59 PM" src="https://github.com/user-attachments/assets/2b2a6b90-19b7-4733-97e6-6b3fe87b332e" />