### PR TITLE
구독 및 결제 히스토리 삭제 부분 버그 해결

### DIFF
--- a/src/main/java/com/subnity/domain/member/Member.java
+++ b/src/main/java/com/subnity/domain/member/Member.java
@@ -50,12 +50,10 @@ public class Member extends BaseTimeEntity {
   private String schedulerId;
 
   @Builder.Default
-  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-  @Column(name = "subscription_id")
+  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
   private List<Subscription> subscriptionList = new ArrayList<>();
 
   @Builder.Default
-  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-  @Column(name = "monthly_report_id")
+  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
   private List<MonthlyReport> monthlyReportList = new ArrayList<>();
 }

--- a/src/main/java/com/subnity/domain/monthly_report/MonthlyReport.java
+++ b/src/main/java/com/subnity/domain/monthly_report/MonthlyReport.java
@@ -49,6 +49,5 @@ public class MonthlyReport {
 
   @Builder.Default
   @OneToMany(mappedBy = "monthlyReport", cascade = CascadeType.ALL, orphanRemoval = true)
-  @Column(name = "category_expense")
   private List<CategoryCost> categoryExpenseList = new ArrayList<>();
 }

--- a/src/main/java/com/subnity/domain/payment_history/PaymentHistory.java
+++ b/src/main/java/com/subnity/domain/payment_history/PaymentHistory.java
@@ -32,6 +32,6 @@ public class PaymentHistory extends BaseTimeEntity {
   private PaymentStatus paymentStatus;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "subscription_id")
+  @JoinColumn(name = "subscription_id", nullable = false)
   private Subscription subscription;
 }

--- a/src/main/java/com/subnity/domain/subscription/Subscription.java
+++ b/src/main/java/com/subnity/domain/subscription/Subscription.java
@@ -67,12 +67,10 @@ public class Subscription extends BaseTimeEntity {
   private Member member;
 
   @Builder.Default
-  @OneToMany(mappedBy = "subscription", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-  @Column(name = "subscription_history")
+  @OneToMany(mappedBy = "subscription", cascade = CascadeType.ALL)
   private List<SubscriptionHistory> historyList = new ArrayList<>();
 
   @Builder.Default
-  @OneToMany(mappedBy = "subscription", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-  @Column(name = "payment_history")
+  @OneToMany(mappedBy = "subscription", cascade = CascadeType.ALL)
   private List<PaymentHistory> paymentHistoryList = new ArrayList<>();
 }

--- a/src/main/java/com/subnity/domain/subscription/repository/SubscrRepository.java
+++ b/src/main/java/com/subnity/domain/subscription/repository/SubscrRepository.java
@@ -97,19 +97,4 @@ public class SubscrRepository {
       )
       .execute();
   }
-
-  /**
-   * 특정 구독 제거
-   * @param subscrId : 구독 ID
-   * @param memberId : 회원 ID
-   */
-  @Transactional
-  public void deleteSubscr(Long subscrId, String memberId) {
-    queryFactory.delete(subscription)
-      .where(
-        subscription.member.memberId.eq(memberId),
-        subscription.subscriptionId.eq(subscrId)
-      )
-      .execute();
-  }
 }

--- a/src/main/java/com/subnity/domain/subscription/service/SubscrService.java
+++ b/src/main/java/com/subnity/domain/subscription/service/SubscrService.java
@@ -104,8 +104,7 @@ public class SubscrService {
    * @param subscrId : 구독 ID
    */
   public void deleteSubscr(String subscrId) {
-    String memberId = SecurityUtils.getAuthMemberId();
-    this.subscrRepository.deleteSubscr(Long.parseLong(subscrId), memberId);
+    this.jpaRepository.deleteById(Long.parseLong(subscrId));
   }
 
   /**


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #40

## 📝 작업 내용
해당 브랜치에서는 구독과 결제 히스토리 삭제 부분에서 JDBC 오류를 해결했습니다. 버고 고치다가 깨달은게 JPA가 제공해주는 기본적인 그니까 CrudRepository에 있는 deleteById()를 사용해야 자동으로 Join한 자식 테이블을 로딩한 후 부모 테이블이 로딩되어 같이 삭제되게 되는 것이었습니다.
그래서 얼른 QueryDsl을 사용해서 구현한 deleteById()를 제거하고 JPA deleteById()로 바꿨습니다. 🤣 
그랬더니 해결~ㅠㅠ